### PR TITLE
Converting to a byte slice before finding length for multibyte characters

### DIFF
--- a/codelingo.yaml
+++ b/codelingo.yaml
@@ -1,0 +1,18 @@
+tenets:
+  - name:  len-rune-multibyte
+    flows:
+      codelingo/review:
+        comment: ps.Forumla supports multibyte characters, so you should convert it to a byte slice ([]byte) before finding its length.
+    query: |
+      import codelingo/ast/go
+      
+      @review comment
+      go.call_expr(depth = any):
+        go.ident:
+          name == "len"
+        go.args:
+          go.selector_expr:
+            go.ident:
+              name == "ps"
+            go.ident:
+              name == "Formula"

--- a/efp.go
+++ b/efp.go
@@ -581,7 +581,7 @@ func (ps *Parser) currentChar() string {
 
 // nextChar provides function to get the next character of the current position.
 func (ps *Parser) nextChar() string {
-	if len(ps.Formula) >= ps.Offset+1 {
+	if len([]rune(ps.Formula)) >= ps.Offset+1 {
 		return ""
 	}
 	return string([]rune(ps.Formula)[ps.Offset+1])


### PR DESCRIPTION
Hi @xuri,

This PR fixes a multibyte support issue that you missed in your [previous PR](https://github.com/xuri/efp/pull/2), and protects your repo from this issue in the future.

We (@codelingo) like to check  up on our open source user as much as possible, so we wrote [a tenet](https://github.com/leilaes/efp/blob/master/codelingo.yaml) that finds places where you call `len` on `ps.Formula` without converting it to a byte slice first. The tenet found this issue, and it'll comment on any pull request that introduces the issue again.

Let me know if this is helpful, or if you want help customising this tenet or writing your own!