### PR TITLE
Speedup: PrettyPrint, Render, and Parse

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@
 
 <!--- Please describe in detail how you tested your changes. -->
 <!--- Include details of your testing environment, and the tests you ran to -->
-<!--- see how your change affects other areas of the code, etc. -->
+<!--- See how your change affects other areas of the code, etc. -->
 
 ## Types of changes
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Contributions are welcome! Open a pull request to fix a bug, or open an issue to
 
 ## Credits
 
-EFP (Excel Formula Parser) is a Golang port of [E. W. Bachtal's](https://ewbi.blogs.com/develops/2004/12/excel_formula_p.html) Excel formula parser.
+EFP (Excel Formula Parser) is a Go language port of E. W. Bachtal's Excel formula parser.
 
 ## Licenses
 

--- a/efp.go
+++ b/efp.go
@@ -119,11 +119,10 @@ type Parser struct {
 	Tokens     Tokens
 	TokenStack Tokens
 	Offset     int
-	//Token      string
-	InString bool
-	InPath   bool
-	InRange  bool
-	InError  bool
+	InString   bool
+	InPath     bool
+	InRange    bool
+	InError    bool
 }
 
 // fToken provides function to encapsulate a formula token.
@@ -136,9 +135,10 @@ func fToken(value []rune, tokenType, subType string) Token {
 }
 
 // fTokens provides function to handle an ordered list of tokens.
-func fTokens() Tokens {
+func fTokens(size, cap int) Tokens {
 	return Tokens{
 		Index: -1,
+		Items: make([]Token, size, cap),
 	}
 }
 
@@ -529,7 +529,7 @@ func (ps *Parser) getTokens() Tokens {
 	}
 
 	// move all tokens to a new collection, excluding all unnecessary white-space tokens
-	tokens2 := fTokens()
+	tokens2 := fTokens(0, len(ps.Tokens.Items))
 
 	for ps.Tokens.moveNext() {
 		token := ps.Tokens.current()
@@ -613,7 +613,7 @@ func (ps *Parser) getTokens() Tokens {
 	tokens2.reset()
 
 	// move all tokens to a new collection, excluding all no-ops
-	tokens := fTokens()
+	tokens := fTokens(0, len(tokens2.Items))
 	for tokens2.moveNext() {
 		if tokens2.current().TType != TokenTypeNoop {
 			tokens.addRef(Token{

--- a/efp.go
+++ b/efp.go
@@ -15,6 +15,7 @@ var operatorsSN map[rune]struct{}
 var operatorsInfix map[rune]struct{}
 var comparisonSet map[string]struct{}
 var errorSet map[string]struct{}
+var expRegex = regexp.MustCompile(`^[1-9]{1}(\.[0-9]+)?E{1}$`)
 
 func init() {
 	operatorsSN = make(map[rune]struct{}, len([]rune(OperatorsSN)))
@@ -326,8 +327,7 @@ func (ps *Parser) getTokens() Tokens {
 
 		// scientific notation check
 		if _, isSN := operatorsSN[ps.currentChar()]; isSN && len(ps.Token) > 1 {
-			r, _ := regexp.Compile(`^[1-9]{1}(\.[0-9]+)?E{1}$`)
-			if r.MatchString(ps.Token) {
+			if expRegex.MatchString(ps.Token) {
 				ps.Token += string(ps.currentChar())
 				ps.Offset++
 				continue

--- a/efp.go
+++ b/efp.go
@@ -38,6 +38,16 @@ func init() {
 	}
 }
 
+func isInComparisonSet(r []rune) bool {
+	if len(r) < 2 {
+		return false
+	}
+
+	return r[0] == '>' && r[1] == '=' ||
+		r[0] == '<' && r[1] == '=' ||
+		r[0] == '<' && r[1] == '>'
+}
+
 // QuoteDouble, QuoteSingle and other's constants are token definitions.
 const (
 	// Character constants
@@ -432,12 +442,12 @@ func (ps *Parser) getTokens() Tokens {
 		}
 
 		// multi-character comparators
-		if _, isComparison := comparisonSet[ps.doubleChar()]; isComparison {
+		if isInComparisonSet(ps.doubleChar()) {
 			if len(token) > 0 {
 				ps.Tokens.add(string(token), TokenTypeOperand, "")
 				token = token[:0]
 			}
-			ps.Tokens.add(ps.doubleChar(), TokenTypeOperatorInfix, TokenSubTypeLogical)
+			ps.Tokens.add(string(ps.doubleChar()), TokenTypeOperatorInfix, TokenSubTypeLogical)
 			ps.Offset += 2
 			continue
 		}
@@ -614,11 +624,11 @@ func (ps *Parser) getTokens() Tokens {
 
 // doubleChar provides function to get two characters after the current
 // position.
-func (ps *Parser) doubleChar() string {
+func (ps *Parser) doubleChar() []rune {
 	if len(ps.fRune) >= ps.Offset+2 {
-		return string(ps.fRune[ps.Offset : ps.Offset+2])
+		return ps.fRune[ps.Offset : ps.Offset+2]
 	}
-	return ""
+	return nil
 }
 
 // currentChar provides function to get the character of the current position.

--- a/efp.go
+++ b/efp.go
@@ -105,6 +105,7 @@ type Tokens struct {
 // tokens.
 type Parser struct {
 	Formula    string
+	fRune      []rune
 	Tokens     Tokens
 	TokenStack Tokens
 	Offset     int
@@ -257,6 +258,7 @@ func (ps *Parser) getTokens() Tokens {
 			ps.Formula = "=" + ps.Formula
 		}
 	}
+	ps.fRune = []rune(ps.Formula)
 
 	var token []rune
 
@@ -319,7 +321,7 @@ func (ps *Parser) getTokens() Tokens {
 			token = append(token, ps.currentChar())
 			ps.Offset++
 
-			if _, isError := errorSet[ps.doubleChar()]; isError {
+			if _, isError := errorSet[string(token)]; isError {
 				ps.InError = false
 				ps.Tokens.add(string(token), TokenTypeOperand, TokenSubTypeError)
 				token = token[:0]
@@ -613,28 +615,28 @@ func (ps *Parser) getTokens() Tokens {
 // doubleChar provides function to get two characters after the current
 // position.
 func (ps *Parser) doubleChar() string {
-	if len([]rune(ps.Formula)) >= ps.Offset+2 {
-		return string([]rune(ps.Formula)[ps.Offset : ps.Offset+2])
+	if len(ps.fRune) >= ps.Offset+2 {
+		return string(ps.fRune[ps.Offset : ps.Offset+2])
 	}
 	return ""
 }
 
 // currentChar provides function to get the character of the current position.
 func (ps *Parser) currentChar() rune {
-	return []rune(ps.Formula)[ps.Offset]
+	return ps.fRune[ps.Offset]
 }
 
 // nextChar provides function to get the next character of the current position.
 func (ps *Parser) nextChar() rune {
-	if len([]rune(ps.Formula)) >= ps.Offset+2 {
-		return []rune(ps.Formula)[ps.Offset+1]
+	if len(ps.fRune) >= ps.Offset+2 {
+		return ps.fRune[ps.Offset+1]
 	}
 	return 0
 }
 
 // EOF provides function to check whether end of tokens stack.
 func (ps *Parser) EOF() bool {
-	return ps.Offset >= len([]rune(ps.Formula))
+	return ps.Offset >= len(ps.fRune)
 }
 
 // Parse provides function to parse formula as a token stream (list).

--- a/efp.go
+++ b/efp.go
@@ -140,6 +140,12 @@ func fToken(value string, tokenType, subType string) Token {
 
 // fTokens provides function to handle an ordered list of tokens.
 func fTokens(size, cap int) Tokens {
+	if size == 0 && cap == 0 {
+		return Tokens{
+			Index: -1,
+		}
+	}
+
 	return Tokens{
 		Index: -1,
 		Items: make([]Token, size, cap),
@@ -621,6 +627,9 @@ func (ps *Parser) getTokens() Tokens {
 	}
 
 	tokens.reset()
+	if len(tokens.Items) == 0 {
+		tokens.Items = nil
+	}
 	return tokens
 }
 

--- a/efp.go
+++ b/efp.go
@@ -620,43 +620,53 @@ func (ps *Parser) Parse(formula string) []Token {
 // format.
 func (ps *Parser) PrettyPrint() string {
 	indent := 0
-	output := ""
+	var output strings.Builder
 	for _, t := range ps.Tokens.Items {
 		if t.TSubType == TokenSubTypeStop {
 			indent--
 		}
 		for i := 0; i < indent; i++ {
-			output += "\t"
+			output.WriteRune('\t')
 		}
-		output += t.TValue + " <" + t.TType + "> <" + t.TSubType + ">" + "\n"
+
+		output.WriteString(t.TValue)
+		output.WriteString(" <")
+		output.WriteString(t.TType)
+		output.WriteString("> <")
+		output.WriteString(t.TSubType)
+		output.WriteString(">\n")
+
 		if t.TSubType == TokenSubTypeStart {
 			indent++
 		}
 	}
-	return output
+	return output.String()
 }
 
 // Render provides function to get formatted formula after parsed.
 func (ps *Parser) Render() string {
-	output := ""
+	var output strings.Builder
 	for _, t := range ps.Tokens.Items {
 		if t.TType == TokenTypeFunction && t.TSubType == TokenSubTypeStart {
-			output += t.TValue + ParenOpen
+			output.WriteString(t.TValue)
+			output.WriteString(ParenOpen)
 		} else if t.TType == TokenTypeFunction && t.TSubType == TokenSubTypeStop {
-			output += ParenClose
+			output.WriteString(ParenClose)
 		} else if t.TType == TokenTypeSubexpression && t.TSubType == TokenSubTypeStart {
-			output += ParenOpen
+			output.WriteString(ParenOpen)
 		} else if t.TType == TokenTypeSubexpression && t.TSubType == TokenSubTypeStop {
-			output += ParenClose
+			output.WriteString(ParenClose)
 		} else if t.TType == TokenTypeOperand && t.TSubType == TokenSubTypeText {
-			output += QuoteDouble + t.TValue + QuoteDouble
+			output.WriteString(QuoteDouble)
+			output.WriteString(t.TValue)
+			output.WriteString(QuoteDouble)
 		} else if t.TType == TokenTypeOperatorInfix && t.TSubType == TokenSubTypeIntersection {
-			output += Whitespace
+			output.WriteString(Whitespace)
 		} else {
-			output += t.TValue
+			output.WriteString(t.TValue)
 		}
 	}
-	return output
+	return output.String()
 }
 
 // inStrSlice provides a method to check if an element is present in an array,

--- a/efp.go
+++ b/efp.go
@@ -108,9 +108,8 @@ type Token struct {
 // Tokens directly maps the ordered list of tokens.
 // Attributes:
 //
-//    items - Ordered list
-//    index - Current position in the list
-//
+//	items - Ordered list
+//	index - Current position in the list
 type Tokens struct {
 	Index int
 	Items []Token
@@ -266,7 +265,6 @@ func ExcelParser() Parser {
 
 // getTokens return a token stream (list).
 func (ps *Parser) getTokens() Tokens {
-
 	ps.Formula = strings.TrimSpace(ps.Formula)
 	ps.fRune = []rune(ps.Formula)
 	if len(ps.fRune) > 0 && ps.fRune[0] != '=' {

--- a/efp_test.go
+++ b/efp_test.go
@@ -1,8 +1,6 @@
 package efp
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestEFP(t *testing.T) {
 	formulae := []string{
@@ -72,7 +70,7 @@ func TestEFP(t *testing.T) {
 	tk.previous()
 }
 
-func TestEFP_Nonformulas(t *testing.T) {
+func TestNonFormulas(t *testing.T) {
 	formulae := []string{
 		``,
 		`+`,

--- a/efp_test.go
+++ b/efp_test.go
@@ -1,6 +1,8 @@
 package efp
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestEFP(t *testing.T) {
 	formulae := []string{
@@ -68,4 +70,22 @@ func TestEFP(t *testing.T) {
 	tk.current()
 	tk.next()
 	tk.previous()
+}
+
+func TestEFP_Nonformulas(t *testing.T) {
+	formulae := []string{
+		``,
+		`+`,
+		``,
+		`                 `,
+	}
+	for _, f := range formulae {
+		t.Run(`"`+f+`"`, func(t *testing.T) {
+			p := ExcelParser()
+			if p.Parse(f) != nil {
+				t.Log(`non-nil result given`)
+				t.Fail()
+			}
+		})
+	}
 }


### PR DESCRIPTION
# PR Details
Using strings.Builder and `[]rune|rune` instead of `string` can dramatic  reduce time, bytes, and allocations. 

Benchmark used:
```go
var benchFormulas = []string{"=0", "=SUM(A3+B9*2)/2"}

func BenchmarkExcelParser(b *testing.B) {
	for _, formula := range benchFormulas {
		b.ResetTimer()

		ps := efp.ExcelParser()
		b.Run(formula, func(b *testing.B) {
			for n := 0; n < b.N; n++ {
				ps.Parse(formula)
			}
		})

		b.Run(formula+`.PrettyPrint()`, func(b *testing.B) {
			for n := 0; n < b.N; n++ {
				ps.PrettyPrint()
			}
		})
		b.Run(formula+`.Render()`, func(b *testing.B) {
			for n := 0; n < b.N; n++ {
				ps.Render()
			}
		})
	}

	for i := 10; i < 10000; i *= 10 {
		f := `=` + strings.Repeat(`SUM(A:C)+`, i) + `0`
		b.Run(`long`+strconv.Itoa(i), func(b *testing.B) {
			for n := 0; n < b.N; n++ {
				ps := efp.ExcelParser()
				ps.Parse(f)
			}
		})
	}
}
```
```
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                                                 old ns/op      new ns/op     delta
BenchmarkExcelParser/=0-10                                371855         79.2          -99.98%
BenchmarkExcelParser/=0.PrettyPrint()-10                  117320611      62.2          -100.00%
BenchmarkExcelParser/=0.Render()-10                       7286553        19.0          -100.00%
BenchmarkExcelParser/=SUM(A3+B9*2)/2-10                   362986         285           -99.92%
BenchmarkExcelParser/=SUM(A3+B9*2)/2.PrettyPrint()-10     95657053       269           -100.00%
BenchmarkExcelParser/=SUM(A3+B9*2)/2.Render()-10          8838701        96.4          -100.00%
BenchmarkExcelParser/long10-10                            264109         5111          -98.06%
BenchmarkExcelParser/long100-10                           21699004       44848         -99.79%
BenchmarkExcelParser/long1000-10                          1719943709     469958        -99.97%

benchmark                                                 old allocs     new allocs     delta
BenchmarkExcelParser/=0-10                                31             3              -90.32%
BenchmarkExcelParser/=0.PrettyPrint()-10                  10137          3              -99.97%
BenchmarkExcelParser/=0.Render()-10                       10103          1              -99.99%
BenchmarkExcelParser/=SUM(A3+B9*2)/2-10                   31             3              -90.32%
BenchmarkExcelParser/=SUM(A3+B9*2)/2.PrettyPrint()-10     10123          6              -99.94%
BenchmarkExcelParser/=SUM(A3+B9*2)/2.Render()-10          10110          2              -99.98%
BenchmarkExcelParser/long10-10                            1542           44             -97.15%
BenchmarkExcelParser/long100-10                           14961          317            -97.88%
BenchmarkExcelParser/long1000-10                          149192         3022           -97.97%

benchmark                                                 old bytes      new bytes     delta
BenchmarkExcelParser/=0-10                                2033207        136           -99.99%
BenchmarkExcelParser/=0.PrettyPrint()-10                  1107914861     56            -100.00%
BenchmarkExcelParser/=0.Render()-10                       54198420       8             -100.00%
BenchmarkExcelParser/=SUM(A3+B9*2)/2-10                   2036515        1088          -99.95%
BenchmarkExcelParser/=SUM(A3+B9*2)/2.PrettyPrint()-10     1109796115     504           -100.00%
BenchmarkExcelParser/=SUM(A3+B9*2)/2.Render()-10          54331333       24            -100.00%
BenchmarkExcelParser/long10-10                            552290         13656         -97.53%
BenchmarkExcelParser/long100-10                           55977446       123840        -99.78%
BenchmarkExcelParser/long1000-10                          5574307520     1316311       -99.98%
```

## Description


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

While using the library, it was discovered that the string -> []rune conversions were causing many allocations.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
    - Removal of `Token string` on the Parser struct
    - Character constants changed type from string to rune

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
