### PR TITLE
fix: add parantheses tokens instead of empty strings

### DIFF
--- a/efp.go
+++ b/efp.go
@@ -491,9 +491,8 @@ func (ps *Parser) getTokens() Tokens {
 			if len(token) > 0 {
 				ps.TokenStack.push(ps.Tokens.add(string(token), TokenTypeFunction, TokenSubTypeStart))
 				token = token[:0]
-			} else {
-				ps.TokenStack.push(ps.Tokens.add("", TokenTypeSubexpression, TokenSubTypeStart))
 			}
+			ps.TokenStack.push(ps.Tokens.add(string(ps.currentChar()), TokenTypeSubexpression, TokenSubTypeStart))
 			ps.Offset++
 			continue
 		}
@@ -519,7 +518,7 @@ func (ps *Parser) getTokens() Tokens {
 				ps.Tokens.add(string(token), TokenTypeOperand, "")
 				token = token[:0]
 			}
-			ps.Tokens.addRef(ps.TokenStack.pop())
+			ps.Tokens.add(string(ps.currentChar()), TokenTypeSubexpression, TokenSubTypeStop)
 			ps.Offset++
 			continue
 		}


### PR DESCRIPTION
# PR Details

This should fix the cut out parentheses in formulas. 

## Description

Description by @losdmi:

> When adding columns or rows and formulas need to be adjusted, the inner parentheses got cut out therefore resulting in corrupted formula

## Related Issue

Original issue reported [here](https://github.com/qax-os/excelize/issues/1861) in excelize. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

I tested with the example provided in the original issue. While it fixes that problem, this is my first time running into excelize so I hope it doesn't break anything else :grimacing: 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
